### PR TITLE
ChangeTreeChromaの仕様変更

### DIFF
--- a/Assets/Member/Yoshida/HitDamageEffectManager.cs
+++ b/Assets/Member/Yoshida/HitDamageEffectManager.cs
@@ -10,17 +10,25 @@ namespace SoulRunProject.InGame
     public class HitDamageEffectManager : MonoBehaviour
     {
         // シェーダーのカラープロパティ取得
-        protected static readonly int PramID = Shader.PropertyToID("_Color");
+        public static readonly int PramID = Shader.PropertyToID("_BaseColor");
 
         // 良い感じの白色
         static readonly Color WhiteColor = new(0.85f, 0.85f, 0.85f, 0.6f);
         [SerializeField, Tooltip("点滅時間")] float _duration;
         [SerializeField, Tooltip("点滅回数")] int _loopCount;
         Renderer _renderer;
-        protected Material _copyMaterial;
+        Material _copyMaterial;
         Sequence _sequence;
-        protected Color _defaultColor;
-        protected bool _hitFadeBlinking;
+        Color _defaultColor;
+        bool _hitFadeBlinking;
+
+        public Material CopyMaterial => _copyMaterial;
+        public Color DefaultColor
+        {
+            get => _defaultColor;
+            set => _defaultColor = value;
+        }
+        public bool HitFadeBlinking => _hitFadeBlinking;
 
         /// <summary>
         /// マテリアルの複製を行う

--- a/Assets/SoulRunProject/GameData/Prefabs/InGame/Stage1/FieldObject/Tree1.prefab
+++ b/Assets/SoulRunProject/GameData/Prefabs/InGame/Stage1/FieldObject/Tree1.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 5844823972712441080}
   - component: {fileID: 43744766646832521}
   - component: {fileID: 3464868641710493916}
+  - component: {fileID: 1436361737371542902}
   m_Layer: 0
   m_Name: Tree1
   m_TagString: Untagged
@@ -129,6 +130,8 @@ MonoBehaviour:
   _lootTable: {fileID: 0}
   _playerManager: {fileID: 0}
   _hitDamageEffectManager: {fileID: 43744766646832521}
+  _useKnockBack:
+    rid: -2
   references:
     version: 2
     RefIds:
@@ -160,3 +163,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 34bcda0e185e7794494ad7f78ba809e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1436361737371542902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1224281310321379123}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50ade48ebdc62294e9934c95787b8c4a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _lightestColor: {r: 0.7372549, g: 0.7372549, b: 0.7372549, a: 1}
+  _darkestColor: {r: 0.1882353, g: 0.25490198, b: 0.4509804, a: 1}
+  _minVariableDistance: 15
+  _maxVariableDistance: 40

--- a/Assets/SoulRunProject/GameData/Prefabs/InGame/Stage1/FieldObject/Tree2.prefab
+++ b/Assets/SoulRunProject/GameData/Prefabs/InGame/Stage1/FieldObject/Tree2.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 8886523578831790948}
   - component: {fileID: -4550613041142796618}
   - component: {fileID: -8645483376259840638}
+  - component: {fileID: 2017836778090743728}
   m_Layer: 0
   m_Name: Tree2
   m_TagString: Untagged
@@ -129,6 +130,8 @@ MonoBehaviour:
   _lootTable: {fileID: 0}
   _playerManager: {fileID: 0}
   _hitDamageEffectManager: {fileID: 0}
+  _useKnockBack:
+    rid: -2
   references:
     version: 2
     RefIds:
@@ -160,3 +163,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 34bcda0e185e7794494ad7f78ba809e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2017836778090743728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2896465790406250595}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50ade48ebdc62294e9934c95787b8c4a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _lightestColor: {r: 0.7372549, g: 0.7372549, b: 0.7372549, a: 1}
+  _darkestColor: {r: 0.1882353, g: 0.25490198, b: 0.4509804, a: 1}
+  _minVariableDistance: 15
+  _maxVariableDistance: 40

--- a/Assets/SoulRunProject/GameData/Prefabs/InGame/Stage1/FieldObject/Tree3.prefab
+++ b/Assets/SoulRunProject/GameData/Prefabs/InGame/Stage1/FieldObject/Tree3.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: -8307266297739542644}
   - component: {fileID: 2358446251508100875}
   - component: {fileID: 6554509360312225382}
+  - component: {fileID: 6801149446428804765}
   m_Layer: 0
   m_Name: Tree3
   m_TagString: Untagged
@@ -129,6 +130,8 @@ MonoBehaviour:
   _lootTable: {fileID: 0}
   _playerManager: {fileID: 0}
   _hitDamageEffectManager: {fileID: 0}
+  _useKnockBack:
+    rid: -2
   references:
     version: 2
     RefIds:
@@ -160,3 +163,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 34bcda0e185e7794494ad7f78ba809e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6801149446428804765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 871129033906405150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50ade48ebdc62294e9934c95787b8c4a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _lightestColor: {r: 0.7372549, g: 0.7372549, b: 0.7372549, a: 1}
+  _darkestColor: {r: 0.1882353, g: 0.25490198, b: 0.4509804, a: 1}
+  _minVariableDistance: 15
+  _maxVariableDistance: 40

--- a/Assets/SoulRunProject/Scripts/InGame/Field/ChangeTreeChroma.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Field/ChangeTreeChroma.cs
@@ -7,7 +7,8 @@ namespace SoulRunProject.InGame
     /// <summary>
     /// 木の色彩をプレイヤーからの距離に応じて変える
     /// </summary>
-    public class ChangeTreeChroma : HitDamageEffectManager
+    [RequireComponent(typeof(HitDamageEffectManager))]
+    public class ChangeTreeChroma : MonoBehaviour
     {
         [SerializeField, Tooltip("最も明るい色")] private Color _lightestColor;
         [SerializeField, Tooltip("最も暗い色")] private Color _darkestColor;
@@ -15,22 +16,22 @@ namespace SoulRunProject.InGame
         [SerializeField, HideInInspector] private float _maxVariableDistance;
 
         private Transform _playerTransform;
+        private HitDamageEffectManager _effectManager;
 
-        protected override void Awake()
+        private void Awake()
         {
-            base.Awake();
-
             _playerTransform = FindObjectOfType<PlayerManager>().transform;
+            _effectManager = GetComponent<HitDamageEffectManager>();
         }
 
         private void Update()
         {
-            if (!_hitFadeBlinking) // HitEffect中は色を変えない
+            if (!_effectManager.HitFadeBlinking) // HitEffect中は色を変えない
             {
                 float xDistance = Vector3.Distance(transform.position, _playerTransform.position);
                 float value = Mathf.Clamp((xDistance - _minVariableDistance) / (_maxVariableDistance - _minVariableDistance), 0, 1);
-                _defaultColor = Color.Lerp(_lightestColor, _darkestColor, value);
-                _copyMaterial.SetColor(PramID, _defaultColor);
+                _effectManager.DefaultColor = Color.Lerp(_lightestColor, _darkestColor, value);
+                _effectManager.CopyMaterial.SetColor(HitDamageEffectManager.PramID, _effectManager.DefaultColor);
             }
         }
 


### PR DESCRIPTION
HitDamageEffectManagerを継承するのではなくほかのScriptとして、マテリアルの参照変更を行うように変更