### PR TITLE
[fix] ノックバックのTweenを対応するgameobjectにsetlinkしてオブジェクトが破棄されるときにtweenが破棄される…

### DIFF
--- a/Assets/Member/Yoshida/TakeKnockBack.cs
+++ b/Assets/Member/Yoshida/TakeKnockBack.cs
@@ -26,6 +26,7 @@ namespace SoulRunProject.Common
             _sequence.Append(myTransform.DOBlendableMoveBy(new Vector3(direction.x, 0f ,direction.z), _knockBackTime));
             _sequence.Insert(0f , myTransform.DOBlendableMoveBy(new Vector3(0f , direction.y ,0f), _knockBackTime / 2));
             _sequence.Insert(_knockBackTime / 2 , myTransform.DOBlendableMoveBy(new Vector3(0f , - direction.y ,0f), _knockBackTime / 2));
+            _sequence.SetLink(myTransform.gameObject);
             await _sequence;
             _sequence = null;
             _isKnockBack = false;


### PR DESCRIPTION
…ようにした。