### PR TITLE
DamageableEntityをオブジェクトプールで管理できるようにして、フィールド生成を軽量化した。

### DIFF
--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool.meta
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 965770a0aecf85541a277e3b98ff2ef4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPool.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPool.cs
@@ -1,0 +1,25 @@
+using SoulRunProject.InGame;
+using UniRx.Toolkit;
+using UnityEngine;
+
+namespace SoulRunProject.Common
+{
+    public class EntityPool : ObjectPool<DamageableEntity>
+    {
+        private readonly DamageableEntity _entity;
+        private Transform _parent;
+        
+        public EntityPool(Transform parent, DamageableEntity entity)
+        {
+            _parent = parent;
+            _entity = entity;
+        }
+        
+        protected override DamageableEntity CreateInstance()
+        {
+            var entity = Object.Instantiate(_entity, _parent);
+            entity.IsPooled = true;
+            return entity;
+        }
+    }
+}

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPool.cs.meta
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2de6667cf5c8a5e4cab06f9f77c8b292
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPoolManager.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPoolManager.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using SoulRunProject.Common;
+using UniRx;
+using UnityEngine;
+
+namespace SoulRunProject.InGame
+{
+    public class EntityPoolManager : AbstractSingletonMonoBehaviour<EntityPoolManager>
+    {
+        [SerializeField] int _preloadCount = 5;
+        [SerializeField] int _threshold = 5;
+        readonly Dictionary<DamageableEntity, EntityPool> _entityPoolDictionary = new();
+        protected override bool UseDontDestroyOnLoad => false;
+
+        public DamageableEntity RequestInstance(DamageableEntity original, Transform parent)
+        {
+            var entityPool = RequestPool(original);
+            var entity = entityPool.Rent();
+            var entityTransform = entity.transform;
+            var prevParent = entityTransform.parent;
+            
+            entityTransform.SetParent(parent);
+            entity.Initialize();
+            entity.OnFinishedAsync.Take(1).Subscribe(_=>
+            {
+                entity.transform.SetParent(prevParent);
+                entityPool.Return(entity);
+            });
+            return entity;
+        }
+        public DamageableEntity RequestInstance(DamageableEntity original, Vector3 position, Quaternion rotation)
+        {
+            var entityPool = RequestPool(original);
+            var entity = entityPool.Rent();
+            var entityTransform = entity.transform;
+            
+            entityTransform.position = position;
+            entityTransform.rotation = rotation;
+            entity.Initialize();
+            entity.OnFinishedAsync.Take(1).Subscribe(_=> entityPool.Return(entity));
+            return entity;
+        }
+        public DamageableEntity RequestInstance(DamageableEntity original, Vector3 position, Quaternion rotation, Transform parent)
+        {
+            var entityPool = RequestPool(original);
+            var entity = entityPool.Rent();
+            var entityTransform = entity.transform;
+            var prevParent = entityTransform.parent;
+            
+            entityTransform.position = position;
+            entityTransform.rotation = rotation;
+            entityTransform.SetParent(parent);
+            entity.Initialize();
+            entity.OnFinishedAsync.Take(1).Subscribe(_=>
+            {
+                entity.transform.SetParent(prevParent);
+                entityPool.Return(entity);
+            });
+            return entity;
+        }
+        public EntityPool RequestPool(DamageableEntity original)
+        {
+            //  既に指定されたIDのpoolが存在していればそのpoolを返す
+            if (_entityPoolDictionary.TryGetValue(original, out var value))
+            {
+                return value;
+            }
+            //  無ければ新しく生成
+            var newParent = new GameObject().transform;
+            newParent.name = original.name;
+            newParent.SetParent(transform);
+            _entityPoolDictionary.Add(original, new EntityPool(newParent, original));
+            _entityPoolDictionary[original].PreloadAsync(_preloadCount, _threshold).Subscribe();
+
+            return _entityPoolDictionary[original];
+        }
+        public override void OnDestroyed()
+        {
+            foreach (var pool in _entityPoolDictionary)
+            {
+                pool.Value.Dispose();
+            }
+        }
+    }
+}

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPoolManager.cs.meta
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityPoolManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a36bfdbcb0072b24a9e403dee581e098
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityRequester.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityRequester.cs
@@ -1,0 +1,91 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+#endif
+using System.Linq;
+using Unity.VisualScripting;
+using UnityEngine;
+
+namespace SoulRunProject.InGame
+{
+    public class EntityRequester : MonoBehaviour
+    {
+        [SerializeField] private DamageableEntity _entity;
+        public DamageableEntity Entity => _entity;
+
+        private void Awake()
+        {
+            if (_entity != null)
+            {
+                EntityPoolManager.Instance.RequestInstance(_entity, transform.position, transform.rotation, transform.parent);
+            }
+            Destroy(gameObject);
+        }
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            Gizmos.color = new Color(1f, 0.76f, 0f);
+            Gizmos.DrawSphere(transform.position, 1f);
+        }
+#endif
+    }
+    #if UNITY_EDITOR
+    [CustomEditor(typeof(EntityRequester))]
+    [CanEditMultipleObjects]
+    public class EntityRequesterEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+            if (GUILayout.Button($"生成する"))
+            {
+                foreach (var obj in targets)
+                {
+                    var requester = obj as EntityRequester;
+                    if (requester.Entity != null)
+                    {
+                        var entity = Instantiate(requester.Entity, requester.transform.position,
+                            requester.transform.rotation, requester.transform.root);
+                        Undo.RegisterCreatedObjectUndo(entity.gameObject, "create " + entity.gameObject.name);
+                    }
+                }
+            }
+            if (GUILayout.Button($"{nameof(EntityRequester)}とTransform以外のコンポーネントを削除"))
+            {
+                foreach (var obj in targets)
+                {
+                    foreach (var component in obj.GetComponents<Component>()
+                                 .Where(c => HasRequireComponent(c.GetType())))
+                    {
+                        if(component is EntityRequester or Transform) continue;
+                        Undo.DestroyObjectImmediate(component);
+                    }
+                    foreach (var component in obj.GetComponents<Component>())
+                    {
+                        if(component is EntityRequester or Transform) continue;
+                        Undo.DestroyObjectImmediate(component);
+                    }
+                }
+            }
+
+            if (GUILayout.Button("子オブジェクトを削除"))
+            {
+                foreach (var obj in targets)
+                {
+                    var requester = obj as EntityRequester;
+                    foreach (Transform child in requester.transform)
+                    {
+                        Undo.DestroyObjectImmediate(child.gameObject);
+                    }
+                }
+            }
+        }
+
+        bool HasRequireComponent(Type type)
+        {
+            object[] attributes = type.GetCustomAttributes(typeof(RequireComponent), true);
+            return attributes.Length > 0;
+        }
+    }
+    #endif
+}

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityRequester.cs.meta
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/ObjectPool/EntityRequester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5302b64ec5eee54db3a818e51570c38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/Spawner/EntitySpawnerController.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/Spawner/EntitySpawnerController.cs
@@ -77,8 +77,7 @@ namespace SoulRunProject.InGame
 
                 yield return new WaitForSeconds(_spawnInterval / 1000);
 
-                // TODO 複数種出す場合、それらを選択するロジックを考える
-                var entity = Instantiate(_fieldEntity[spawnIndex], transform.position + pos.Item1,
+                var entity = EntityPoolManager.Instance.RequestInstance(_fieldEntity[spawnIndex], transform.position + pos.Item1,
                     Quaternion.Euler(0, pos.Item2, 0));
                 //entity.SetPlayer(_playerManager);
                 spawnIndex++;

--- a/Assets/SoulRunProject/Scripts/InGame/Field/FieldMover.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Field/FieldMover.cs
@@ -16,6 +16,12 @@ namespace SoulRunProject.InGame
         /// <summary>現在空いているタイルの生成数</summary>
         public int FreeMoveSegmentsCount => Mathf.Clamp(_maxSegmentCount - MoveSegments.Count, 0, _maxSegmentCount);
 
+        public float ScrollSpeed
+        {
+            get => _scrollSpeed;
+            set => _scrollSpeed = value;
+        }
+
         private void Update()
         {
             if (_isPause) return;
@@ -27,6 +33,10 @@ namespace SoulRunProject.InGame
                 //  FieldMoverのz座標より後ろに行ったら消す
                 if (MoveSegments[i].transform.TransformPoint(MoveSegments[i].EndPos).z < transform.position.z)
                 {
+                    foreach (var entity in MoveSegments[i].transform.GetComponentsInChildren<DamageableEntity>())
+                    {
+                        entity.Finish();
+                    }
                     //  破棄する。
                     Destroy(MoveSegments[i].gameObject);
                 }

--- a/Assets/SoulRunProject/Scripts/InGame/Field/FieldSegment.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Field/FieldSegment.cs
@@ -29,9 +29,9 @@ namespace SoulRunProject.InGame
             set => _endPos = value;
         }
     }
-
+#if UNITY_EDITOR
     [CustomEditor(typeof(FieldSegment))]
-    public class FieldSegmentEditor : UnityEditor.Editor
+    public class FieldSegmentEditor : Editor
     {
         FieldSegment _fieldSegment;
 
@@ -59,4 +59,5 @@ namespace SoulRunProject.InGame
             }
         }
     }
+#endif
 }


### PR DESCRIPTION
## フィールドの軽量化
EntityRequesterというオブジェクトプールからDamageableEntityを取り寄せるコンポーネントを作成した。
使い方は現状のDamageableEntity直置き状態の物から、不要な子オブジェクトを削除してTransform以外のコンポーネントを剥がしてEntityRequesterを付ける。
![image](https://github.com/VGA-GLAB/2024_TeamC/assets/134473854/94c64323-bca9-47b4-be9c-4448a04e8d45)
※今のところオブジェクトプールで使いまわせるようにDamageableEntityに初期化処理でhpをリセットするようにしているが、付属している他のコンポーネントは初期化されないので問題が出る可能性がある。