### PR TITLE
[update] エネミーがプレイヤーの後ろに行くと、プールに戻るように変更

### DIFF
--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/DamageableEntity.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/DamageableEntity.cs
@@ -40,6 +40,7 @@ namespace SoulRunProject.InGame
         public FloatReactiveProperty CurrentHp => _currentHp;
         private PlayerManager _player;
         private EnemyController _enemyController;
+        private bool _isDead;
 
         void Start()
         {
@@ -69,6 +70,7 @@ namespace SoulRunProject.InGame
 
             if (_currentHp.Value <= 0)
             {
+                _isDead = true;
                 Death();
             }
 
@@ -85,12 +87,13 @@ namespace SoulRunProject.InGame
 
         public override void OnFinish()
         {
+            _isDead = false;
             OnDead = null;
         }
 
-        void Death()
+        public void Death()
         {
-            if (_lootTable)
+            if (_lootTable && _isDead)
             {
                 DropManager.Instance.RequestDrop(_lootTable, transform.position);
             }

--- a/Assets/SoulRunProject/Scripts/InGame/Enemy/EnemyController.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Enemy/EnemyController.cs
@@ -12,11 +12,13 @@ namespace SoulRunProject.InGame
         protected EntityMover _mover;
         protected Transform _playerTransform;
         private Animator _animator;
+        private DamageableEntity _damageableEntity;
 
         private void Awake()
         {
             Register();
             _animator = GetComponent<Animator>();
+            _damageableEntity = GetComponent<DamageableEntity>();
         }
 
         private void OnDestroy()
@@ -46,6 +48,11 @@ namespace SoulRunProject.InGame
         {
             _mover?.OnUpdateMove(transform, _playerTransform);
             _attacker?.OnUpdateAttack(transform, _playerTransform);
+
+            if (_playerTransform.position.z > gameObject.transform.position.z)
+            {
+                _damageableEntity.Death();
+            }
         }
 
         public void Register()


### PR DESCRIPTION
EnemyはUpdate内でPlayer座標を監視し、
Player座標よりも後ろに行くと、
DamageableEntityのDeathメソッド呼ぶ。
このとき、DeathメソッドはHPが0になった際の処理とは別