### PR TITLE
アイテムが加速する問題を修正した。

### DIFF
--- a/Assets/SoulRunProject/Scripts/InGame/Drop/DropBase.cs
+++ b/Assets/SoulRunProject/Scripts/InGame/Drop/DropBase.cs
@@ -107,6 +107,11 @@ namespace SoulRunProject.InGame
             _rotateTween = null;
             _projectileMotionSequence?.Kill();
             _projectileMotionSequence = null;
+            if (Parent && ActiveParent)
+            {
+                Parent.Targets.Remove(transform);
+                ActiveParent = false;
+            }
         }
 
         private void OnTriggerEnter(Collider other)


### PR DESCRIPTION
フィールドの移動量に合わせて移動する処理をDisable時に登録解除し忘れていたので複数のフィールドに登録されてしまい、フィールドの移動量の2倍や3倍になっていた。